### PR TITLE
Update play-auto-reload to work with play 2.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "com.jamesward"
 
 scalaVersion := "2.10.2"
 
-version := "0.0.7"
+version := "0.0.8"
 
 sbtPlugin := true
 

--- a/src/main/scala/com/jamesward/play/BrowserNotifierPlugin.scala
+++ b/src/main/scala/com/jamesward/play/BrowserNotifierPlugin.scala
@@ -26,15 +26,13 @@ object BrowserNotifierPlugin extends Plugin {
   }
 
   val browserNotification = TaskKey[Unit]("browser-notification")
-  
+
   val compileTask = (compile in Compile, baseDirectory, state) mapR { (a, dir, state) =>
     openSockets foreach (_.send("reload"))
   }
-  
-  val playAssetsDirectories = SettingKey[Seq[File]]("play-assets-directories")
 
   lazy val livereload = Seq(
-    watchSources <++= playAssetsDirectories map { dirs =>
+    watchSources <++= unmanagedResourceDirectories in Compile map { dirs =>
       for {
         dir <- dirs
         file <- (dir.*** --- dir).get


### PR DESCRIPTION
Wanted to get auto reloading working for play 2.3, and this seems to do the trick.

 (Closes #17)
