### PR TITLE
Use open on the Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Setup
 
         sbt ~run
         
-or
+   or
 
         activator ~run
 

--- a/src/main/scala/com/jamesward/play/BrowserNotifierPlugin.scala
+++ b/src/main/scala/com/jamesward/play/BrowserNotifierPlugin.scala
@@ -16,7 +16,6 @@ object BrowserNotifierKeys {
 }
 
 object BrowserNotifierPlugin extends AutoPlugin {
-
   val openSockets = collection.mutable.ListBuffer.empty[WebSocket]
 
   try {
@@ -48,7 +47,10 @@ object BrowserNotifierPlugin extends AutoPlugin {
   val autoOpen = Def.setting {
     PlayRunHook.makeRunHookFromOnStarted { _ =>
       if (BrowserNotifierKeys.shouldOpenBrowser.value) {
-        Desktop.getDesktop.browse(new URI(s"http://localhost:$port"))
+        sys.props("os.name").toLowerCase match {
+          case x if x contains "mac" => s"open http://localhost:$port".!
+          case _ => Desktop.getDesktop.browse(new URI(s"http://localhost:$port"))
+        }
       }
       ()
     }


### PR DESCRIPTION
Here's a small improvement to the open automatically stuff. On the Mac you can use the command line tool `open`, this avoids creating an AWT Desktop instance that also shows an ugly Java icon in the Dock while the Play app is running.
