### PR TITLE
Check Desktop.isDesktopSupported before making call to Desktop.getDesktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Setup
 
 1. Add the SBT plugin to your `project/plugins.sbt` file (make sure to add an empty line before this one):
 
-        addSbtPlugin("com.jamesward" % "play-auto-refresh" % "0.0.11")
+        addSbtPlugin("com.jamesward" % "play-auto-refresh" % "0.0.12")
         
 2. The plugin bootstraps itself automatically as soon as you enable Play in your project.
 
@@ -46,6 +46,7 @@ Release Info
 * 0.0.9 - Migrate to an sbt 0.13.5 auto-plugin
 * 0.0.10 - Use the configured Play port to tell the Chrome plugin which URL to reload
 * 0.0.11 - Automatically open the browser window when you run your app
+* 0.0.12 - Prevent plugin from failing when running in a headless environment
 
 Developer Info
 --------------

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.10.3"
 
 javacOptions ++= Seq("-source", "1.6", "-target", "1.6")
 
-version := "0.0.11"
+version := "0.0.12"
 
 sbtPlugin := true
 

--- a/src/main/scala/com/jamesward/play/BrowserNotifierPlugin.scala
+++ b/src/main/scala/com/jamesward/play/BrowserNotifierPlugin.scala
@@ -44,15 +44,18 @@ object BrowserNotifierPlugin extends AutoPlugin {
     openSockets foreach (_.send(s"reload:$port"))
   }
 
+  private[this] def openBrowser: Unit = {
+    sys.props("os.name").toLowerCase match {
+      case x if x contains "mac" => s"open http://localhost:$port".!
+      case _ if Desktop.isDesktopSupported => Desktop.getDesktop.browse(new URI(s"http://localhost:$port"))
+      case _ => println("Attempted to open web browser, but the current desktop environment is not supported.")
+    }
+  }
+
   val autoOpen = Def.setting {
     PlayRunHook.makeRunHookFromOnStarted { _ =>
-      if (BrowserNotifierKeys.shouldOpenBrowser.value) {
-        sys.props("os.name").toLowerCase match {
-          case x if x contains "mac" => s"open http://localhost:$port".!
-          case _ => Desktop.getDesktop.browse(new URI(s"http://localhost:$port"))
-        }
-      }
-      ()
+      if (BrowserNotifierKeys.shouldOpenBrowser.value) openBrowser
+      else ()
     }
   }
 


### PR DESCRIPTION
As per recommended usage in the docs: https://docs.oracle.com/javase/7/docs/api/java/awt/Desktop.html#getDesktop()

Autoreloading still works when running headless (assuming you are port forwarding back to host), just no more requirement to turn the autolaunch option off to get the project to compile.