### PR TITLE
Play 2.4.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Setup
 
 1. Add the SBT plugin to your `project/plugins.sbt` file (make sure to add an empty line before this one):
 
-        addSbtPlugin("com.jamesward" % "play-auto-refresh" % "0.0.12")
+        addSbtPlugin("com.jamesward" % "play-auto-refresh" % "0.0.13")
         
 2. The plugin bootstraps itself automatically as soon as you enable Play in your project.
 
@@ -24,7 +24,7 @@ Setup
 
 5. The browser window should open automatically (if you don't want this, set `BrowserNotifierKeys.shouldOpenBrowser := false`)
 
-        For play 2.3.x, edit `build.sbt`:
+        For play 2.4.x, edit `build.sbt`:
         
         - Add `import com.jamesward.play.BrowserNotifierKeys` at header
         - Add `BrowserNotifierKeys.shouldOpenBrowser := false` at footer
@@ -47,6 +47,7 @@ Release Info
 * 0.0.10 - Use the configured Play port to tell the Chrome plugin which URL to reload
 * 0.0.11 - Automatically open the browser window when you run your app
 * 0.0.12 - Prevent plugin from failing when running in a headless environment
+* 0.0.13 - Fix incompatibility with Play 2.4.x
 
 Developer Info
 --------------

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ name := "play-auto-refresh"
 
 organization := "com.jamesward"
 
-scalaVersion := "2.10.3"
+scalaVersion := "2.10.4"
 
-javacOptions ++= Seq("-source", "1.6", "-target", "1.6")
+javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
 version := "0.0.12"
 
@@ -24,4 +24,4 @@ licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 
 bintrayOrganization in bintray := None
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.+" % "provided")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.+" % "provided")

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.10.4"
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
-version := "0.0.12"
+version := "0.0.13"
 
 sbtPlugin := true
 

--- a/src/main/scala/com/jamesward/play/BrowserNotifierPlugin.scala
+++ b/src/main/scala/com/jamesward/play/BrowserNotifierPlugin.scala
@@ -3,7 +3,7 @@ package com.jamesward.play
 import java.awt.Desktop
 
 import _root_.play.PlayImport.PlayKeys
-import play.{Play, PlayRunHook}
+import play.sbt.{Play, PlayRunHook}
 import sbt.Keys._
 import sbt._
 import unfiltered.netty._


### PR DESCRIPTION
Was doing a dry run to see how difficult the changes in 2.4 would be to upgrade to, and noticed that this plugin broke due to a namespace change.

With this, the plugin when upgraded won't be backwards compatible.

Historically this plugin has just kept bumping patch versions, even on major changes. Perhaps a good time to switch to semver?

(Would like to retest this changeset before merging the PR when 2.4.0 final goes out. Tested w/ 2.4.0-RC2 explicitly, and then just made the assumed change to 2.4.+ in the build file)