### PR TITLE
Play 2.9, sbt 1.9, latest Scala versions, Java 11, no more sbt-bintray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /project/target
 /.idea
 /.idea_modules
+.bsp/

--- a/README.md
+++ b/README.md
@@ -8,19 +8,25 @@ Setup
 
 1. Add the SBT plugin to your `project/plugins.sbt` file (make sure to add an empty line before this one):
 
-        addSbtPlugin("com.jamesward" % "play-auto-refresh" % "0.0.18")
-        
+```sbt
+addSbtPlugin("com.jamesward" % "play-auto-refresh" % "0.0.18")
+```
+
 2. The plugin bootstraps itself automatically as soon as you enable Play in your project.
 
 3. Add the [Play Framework Tools](https://chrome.google.com/webstore/detail/play-framework-tools/dchhggpgbommpcjpogaploblnpldbmen) Chrome Extension
 
 4. Start your Play app in file watch mode:
 
-        sbt ~run
+```sh
+sbt ~run
+```
 
 5. The browser window should open automatically. If you don't want this add the following to your `build.sbt`:
 
-        shouldOpenBrowser := false
+```sbt
+shouldOpenBrowser := false
+```
 
 6. Make a change to the code for your application and watch your changes magically appear in your browser!
 
@@ -46,9 +52,14 @@ Release Info
 * 0.0.16 - Bump to Play 2.6 and sbt 1.0
 * 0.0.17 - Bump to Play 2.7
 * 0.0.18 - Bump to Play 2.8
+* 0.0.19 - Bump to Play 2.9
 
 Developer Info
 --------------
+
+### Chrome Extension
+
+The source code of the extension can be found here: https://github.com/jamesward/play-framework-chrome-tools
 
 ### Test Project
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "play-auto-refresh"
 
 organization := "com.jamesward"
 
-scalaVersion := "2.12.11"
+scalaVersion := "2.12.18"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation")
 
@@ -14,7 +14,7 @@ description := "Auto refresh for Play Framework apps"
 
 publishMavenStyle := false
 
-libraryDependencies += "ws.unfiltered" %% "unfiltered-netty-websockets" % "0.9.1"
+libraryDependencies += "ws.unfiltered" %% "unfiltered-netty-websockets" % "0.12.0"
 
 licenses += "MIT" -> url("http://opensource.org/licenses/MIT")
 
@@ -28,4 +28,4 @@ bintrayRepository := "sbt-plugins"
 
 bintrayOrganization in bintray := None
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1" % Provided)
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0" % Provided)

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.12.18"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation")
 
-javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
+javacOptions ++= Seq("--release", "11")
 
 description := "Auto refresh for Play Framework apps"
 

--- a/build.sbt
+++ b/build.sbt
@@ -22,10 +22,4 @@ enablePlugins(GitVersioning)
 
 git.useGitDescribe := true
 
-bintrayVcsUrl := Some("git@github.com/jamesward/play-auto-refresh.git")
-
-bintrayRepository := "sbt-plugins"
-
-bintrayOrganization in bintray := None
-
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0" % Provided)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
+addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")

--- a/src/main/scala/com/jamesward/play/BrowserNotifierPlugin.scala
+++ b/src/main/scala/com/jamesward/play/BrowserNotifierPlugin.scala
@@ -47,8 +47,8 @@ object BrowserNotifierPlugin extends AutoPlugin {
     openBrowser := maybeOpenBrowser(shouldOpenBrowser.value, PlayKeys.playDefaultPort.value, streams.value.log),
     shouldOpenBrowser := true,
     PlayKeys.playRunHooks += new BrowserNotifierPlayRunHook(state.value, streams.value.log),
-    compile in Compile := {
-      val compileAnalysis = (compile in Compile).value
+    Compile / compile := {
+      val compileAnalysis = (Compile / compile).value
       browserNotification.value
       compileAnalysis
     }

--- a/test-project/build.sbt
+++ b/test-project/build.sbt
@@ -2,7 +2,7 @@ enablePlugins(PlayScala)
 
 name := "test-project"
 
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.12"
 
 libraryDependencies += guice
 

--- a/test-project/project/build.properties
+++ b/test-project/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.9.7

--- a/test-project/project/plugins.sbt
+++ b/test-project/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0")
 
 lazy val playAutoRefreshPlugin = RootProject(file("..").getAbsoluteFile.toURI)
 


### PR DESCRIPTION
@jamesward For releasing we need to figure out something else, bintray will not work anymore.
To release it to https://repo1.maven.org/maven2/com/jamesward/ I could set up a GitHub actions workflow so we can use https://github.com/sbt/sbt-ci-release, however you would have to add you secrets to this repo first:
https://github.com/sbt/sbt-ci-release#secrets

```
PGP_PASSPHRASE
PGP_SECRET
SONATYPE_PASSWORD
SONATYPE_USERNAME
```

Using sbt-ci-release we can just push a tag and the release will happen automagically.
~Also, feel free to add me as collaborator to this repo if you don't mind :wink: (maybe also to https://github.com/jamesward/play-framework-chrome-tools?)~ Ups I am already, haha didn't know.

wdyt?